### PR TITLE
Remove confirmation for console shell

### DIFF
--- a/lang/de.SharpDoxConsole.sdlang
+++ b/lang/de.SharpDoxConsole.sdlang
@@ -1,3 +1,2 @@
 ConfigMissing = Bitte eine Konfigurationsdatei angeben.
 Path = PFAD
-PressToEnd = Enter drücken, um sharpDox zu verlassen ...

--- a/src/Shells/SharpDox.Console/Main.cs
+++ b/src/Shells/SharpDox.Console/Main.cs
@@ -43,8 +43,6 @@ namespace SharpDox.Console
                 System.Console.WriteLine(_strings.ConfigMissing + " -config " + _strings.Path);
             }
 
-            System.Console.WriteLine(_strings.PressToEnd);
-            System.Console.ReadLine();
         }
         
         public bool IsGui { get { return false; } }

--- a/src/Shells/SharpDox.Console/SDConsoleStrings.cs
+++ b/src/Shells/SharpDox.Console/SDConsoleStrings.cs
@@ -6,7 +6,6 @@ namespace SharpDox.Console
     {
         private string _configMissing = "Please provide a config file.";
         private string _path = "PATH";
-        private string _pressToEnd = "Press enter to exit sharpDox ...";
 
         public string DisplayName { get { return "SharpDoxConsole"; } }
 
@@ -22,10 +21,5 @@ namespace SharpDox.Console
             set { _path = value; }
         }
 
-        public string PressToEnd
-        {
-            get { return _pressToEnd; }
-            set { _pressToEnd = value; }
-        }
     }
 }


### PR DESCRIPTION
As console application it would be suited to run without any user input.

Developers usually need to generate documentation for various projects in succession and do not wish the first run to block all the other projects.